### PR TITLE
added license information to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ authors = [
     {name = "Samuel Yvon"}
 ]
 maintainers = [{name = "Samuel Yvon", email = "samuelyvon9@gmail.com" }]
+license = "MIT"
 
 [build-system]
 requires = ["maturin>=0.13,<0.14"]


### PR DESCRIPTION
it would be nice to have license information in `pyproject.toml` according to the `LICENSE` file