### PR TITLE
Updating how wheels are being built. Fixing py36,37 support

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -6,76 +6,151 @@ on:
       - dev
       - master
   pull_request:
+    branches:
       - dev
 
 jobs:
 
   lint-check:
+    name: Check
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - run: pip install -U pip maturin
       - run: pip install .[dev]
       - run: ./hooks/pre-commit
 
   linux:
-    runs-on: ubuntu-latest
+    name: Build Linux wheels
     needs: [ lint-check ]
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
     - uses: messense/maturin-action@v1
       with:
-        manylinux: auto
+        manylinux: 2_28
+        target: x86_64
         command: build
-        args: --release --sdist -o dist --find-interpreter
+        args: --release --sdist -o dist
     - name: Upload wheels
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
+      with:
+        name: wheels
+        path: dist
+
+  linux-cross:
+    name: Build Linux wheels
+    needs: [ lint-check ]
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target: [s390x, ppc64le, aarch64]
+    steps:
+    - uses: actions/checkout@v3
+    - uses: messense/maturin-action@v1
+      with:
+        manylinux: 2_28
+        target: ${{ matrix.target }}
+        # workaround for PyO3/maturin-action/issues/137
+        container: ghcr.io/rust-cross/manylinux_2_28-cross:${{ matrix.target }}
+        command: build
+        args: --release -o dist
+    - name: Upload wheels
+      uses: actions/upload-artifact@v3
+      with:
+        name: wheels
+        path: dist
+
+  linux-musl:
+    name: Build Linux musl wheels
+    needs: [ lint-check ]
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target: [x86_64, aarch64, i686, armv7l]
+    steps:
+    - uses: actions/checkout@v3
+    - uses: messense/maturin-action@v1
+      with:
+        manylinux: musllinux_1_1
+        target: ${{ matrix.target }}
+        command: build
+        args: --release -o dist
+    - name: Upload wheels
+      uses: actions/upload-artifact@v3
+      with:
+        name: wheels
+        path: dist
+
+  linux-legacy:
+    name: Build Linux legacy wheels
+    needs: [ lint-check ]
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        target: [x86_64, s390x, ppc64le]
+    steps:
+    - uses: actions/checkout@v3
+    # TODO: Figure out a smarter way to do this
+    - run: sed -e "s/requires-python = \">=3.7\"/requires-python = \">=3.6\"/g" -i pyproject.toml
+    - run: sed -e "s/, \"abi3-py37\"//g" -i Cargo.toml
+    - run: sed -e "s/0.17.1/0.15.2/g" -i Cargo.toml
+    - uses: messense/maturin-action@v1
+      with:
+        maturin-version: v0.12.20
+        manylinux: 2014
+        target: ${{ matrix.target }}
+        command: build
+        args: --release -o dist -i python3.6
+    - name: Upload wheels
+      uses: actions/upload-artifact@v3
       with:
         name: wheels
         path: dist
 
   windows:
-    runs-on: windows-latest
+    name: Build Windows wheels
     needs: [ lint-check ]
+    runs-on: windows-latest
     steps:
     - uses: actions/checkout@v3
     - uses: messense/maturin-action@v1
       with:
         command: build
-        args: --release -o dist --find-interpreter
+        args: --release -o dist
     - name: Upload wheels
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: wheels
         path: dist
 
   macos:
-    runs-on: macos-latest
+    name: Build MacOS wheels
     needs: [ lint-check ]
+    runs-on: macos-12
     steps:
     - uses: actions/checkout@v3
     - uses: messense/maturin-action@v1
       with:
         command: build
-        args: --release -o dist --universal2 --find-interpreter
+        args: --release -o dist --universal2
     - name: Upload wheels
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: wheels
         path: dist
 
   release:
-    name: Release
+    needs: [ macos, windows, linux, linux-cross, linux-musl ]
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/master'
-    needs: [ macos, windows, linux ]
     steps:
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: wheels
-      - name: Publish to PyPI
-        uses: messense/maturin-action@v1
-        env:
-          MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+          path: dist
+
+      - uses: pypa/gh-action-pypi-publish@v1
         with:
-          command: upload
-          args: --skip-existing *
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,8 +8,9 @@ edition = "2021"
 name = "netifaces"
 crate-type = ["cdylib"]
 
-[dependencies]
-pyo3 = { version = "0.17.1", features = ["extension-module"] }
+[dependencies.pyo3]
+version = "0.17.1"
+features = ["extension-module", "abi3-py37"]
 
 [target.'cfg(windows)'.dependencies]
 windows = { version = "0.42.0", features = [

--- a/README.md
+++ b/README.md
@@ -62,8 +62,14 @@ route is set.
 
 ## 4. Platform support
 
-For now, I target Linux and MacOS, with Windows support expected in version >=2.0.0. The minimum python
-version you can use is Python 3.5. The linux target for python is `manylinux2014`.
+### Wheels
+Building Linux, Windows and macOS cp37-abi3 wheels (requires Python 3.7 and newer)  
+Install using pip:  
+`python -m pip install netifaces2`
+
+#### Linux  
+Targeting manylinux_2_28 (requires pip>=20.3)  
+Building also cp36m-manylinux2014 wheels for distros using Python 3.6
 
 ## 5. License
 

--- a/netifaces/defs.py
+++ b/netifaces/defs.py
@@ -1,5 +1,7 @@
 from enum import IntEnum
-from typing import Dict, List, Literal, Tuple, Union
+from typing import Dict, List, Tuple, Union
+
+from typing_extensions import Literal
 
 AF_UNSPEC = 0
 AF_UNIX = 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,31 +1,47 @@
 [project]
 name = "netifaces2"
+description = "Portable network interface information"
 version = "0.0.12"
-requires-python = ">=3.5"
+requires-python = ">=3.7"
+readme = "README.md"
+license = {file = "LICENSE"}
 classifiers = [
     "Programming Language :: Rust",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: POSIX :: Linux",
+    "Operating System :: MacOS",
+    "Operating System :: Microsoft :: Windows",
+    "Topic :: System :: Networking"
 ]
-homepage = "https://github.com/SamuelYvon/netifaces-2"
-repository = "https://github.com/SamuelYvon/netifaces-2"
 authors = [
-    {email = "samuelyvon9@gmail.com"},
-    {name = "Samuel Yvon"}
+    { name = "Samuel Yvon", email = "samuelyvon9@gmail.com" }
 ]
-maintainers = [{name = "Samuel Yvon", email = "samuelyvon9@gmail.com" }]
-license = {file = "LICENSE"}
+maintainers = [
+    { name = "Samuel Yvon", email = "samuelyvon9@gmail.com" }
+]
+
+[project.urls]
+homepage = "https://github.com/SamuelYvon/netifaces-2"
+issues = "https://github.com/SamuelYvon/netifaces-2/issues"
+
+[project.optional-dependencies]
+dev = [
+    "mypy >= 0.981",
+    "black >= 22.10.0",
+    "isort >= 5.10.1",
+]
 
 [build-system]
-requires = ["maturin>=0.13,<0.14"]
+requires = ["maturin>=0.14,<0.15"]
 build-backend = "maturin"
-
-[tool.isort]
-profile = "black"
 
 [tool.maturin]
 bindings = "pyo3"
-compatibility = "manylinux2014"
+
+[tool.isort]
+profile = "black"
 
 [[tool.mypy.overrides]]
 module="rs_netifaces"
@@ -34,13 +50,3 @@ ignore_missing_imports=true
 [[tool.mypy.overrides]]
 module="netifaces.netifaces"
 ignore_missing_imports=true
-
-[project.optional-dependencies]
-dev = [
-    "mypy >= 0.981",
-    "black >= 22.10.0",
-    "isort >= 5.10.1"
-]
-
-
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ version = "0.0.12"
 requires-python = ">=3.7"
 readme = "README.md"
 license = {file = "LICENSE"}
+dependencies = ['typing-extensions']
 classifiers = [
     "Programming Language :: Rust",
     "Programming Language :: Python :: Implementation :: CPython",


### PR DESCRIPTION
As mentioned in #5, current netifaces2 wheels are broken on python3.6. PyO3 dropped 3.6 support in 0.16.  
I've tried to update the build process to increase compatibility and switch to building py37 abi3 wheels.

- Linting step was failing on install: Fixed by installing maturin
- Moving to manylinux_2_28
- Cross compiling linux wheels to more architectures
- Building musllinux wheels
- Touching up the pyproject.toml
- Trying (ugly) py36 wheel building. Needs changes in `Cargo.toml` and `pyproject.toml` before being build.
- In defs.py, there is `from typing import Literal`, which was only introduced in 3.8:   
Solved by using `[typing-extensions](https://pypi.org/project/typing-extensions/)`.

So far I only tested the linux py37-abi3 x86_64 wheel on Python 3.9 (el.8) and cpy36m manylinux2014 x86_64 wheel on Python 3.6 (el.7), both seemed to be working fine. 
