### PR TITLE
Adding aarch64, ppc64 py36 wheels

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -87,7 +87,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        target: [x86_64, s390x, ppc64le]
+        target: [x86_64, s390x, ppc64le, aarch64]
     steps:
     - uses: actions/checkout@v3
     # TODO: Figure out a smarter way to do this


### PR DESCRIPTION
@SamuelYvon I somehow missed python3.6 on ARM in the last PR. The use-case for it is on .el8 (RHEL-8, CentOS...).
RHEL-7 is also still supported, while there is no aarch64 version, there is `ppc64` (non-le), which can also be built on Manylinux2014. Would you be against adding it also, to have complete EL coverage?

Please note that when I tested wheels from my fork's CI, they did not really work, the netifaces module had no address families (all wheels, not just py36). 
I'm not quite sure why. Maybe something got broken in upstream? The ubuntu images got updated recently and have different rust, rust tools versions, but maybe I'm missing something.