### PR TITLE
Switching to ubuntu-20.04, manylinux 2_17 for abi3

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -22,12 +22,12 @@ jobs:
   linux:
     name: Build Linux wheels
     needs: [ lint-check ]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v3
     - uses: messense/maturin-action@v1
       with:
-        manylinux: 2_28
+        manylinux: 2_17
         target: x86_64
         command: build
         args: --release --sdist -o dist
@@ -40,18 +40,16 @@ jobs:
   linux-cross:
     name: Build Linux wheels
     needs: [ lint-check ]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
-        target: [s390x, ppc64le, aarch64]
+        target: [i686, s390x, ppc64, ppc64le, aarch64, armv7l]
     steps:
     - uses: actions/checkout@v3
     - uses: messense/maturin-action@v1
       with:
-        manylinux: 2_28
+        manylinux: 2_17
         target: ${{ matrix.target }}
-        # workaround for PyO3/maturin-action/issues/137
-        container: ghcr.io/rust-cross/manylinux_2_28-cross:${{ matrix.target }}
         command: build
         args: --release -o dist
     - name: Upload wheels
@@ -97,7 +95,7 @@ jobs:
     - uses: messense/maturin-action@v1
       with:
         maturin-version: v0.12.20
-        manylinux: 2014
+        manylinux: 2_17
         target: ${{ matrix.target }}
         command: build
         args: --release -o dist -i python3.6


### PR DESCRIPTION
I was not able to reopen the last PR, sorry for the mess.  
What I've learned is that building cp37 abi wheels on higher python versions was not the greatest idea, as the wheels were bot being able to be installed when I tried RHEL-7.9 with rh-python38. Again, sorry!  
With ubuntu-20.04 and manylinux 2_17 (aka 2014), it works fine. I've also tried python3.7 on Fedora and that works fine also.

Manylinux 2_17 will be EOL June 2024, so I'd propose keeping it till then, as it allows also building ppc64, i686.

To add to this, I find building `ppc64` (not le) as part of the cp36 "legacy" would be just too much trouble, as manylinux-cross does not copy python from manylinux images for armv7l and ppc64 as it does for the rest and there simply is not python3.6.

Removing the workaround line, as it was fixed upstream.

The missing AF_ seems to fixed by your changes, thanks!