### PR TITLE
Adding tests ci framework with nox

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -31,6 +31,18 @@ jobs:
         target: x86_64
         command: build
         args: --release --sdist -o dist
+    - uses: actions/setup-python@v4
+      with:
+        python-version: |
+          3.7
+          3.8
+          3.9
+          3.10
+          3.11
+    - name: Test wheels
+      run: |
+        pip install nox
+        nox
     - name: Upload wheels
       uses: actions/upload-artifact@v3
       with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
         args: [--markdown-linebreak-ext=md]
 
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.0.240
+    rev: v0.0.252
     hooks:
       - id: ruff
 
@@ -32,9 +32,10 @@ repos:
       - id: black
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.991
+    rev: v1.0.1
     hooks:
     -   id: mypy
+        additional_dependencies: [nox]
 
   - repo: https://github.com/DevinR528/cargo-sort
     rev: v1.0.9

--- a/README.md
+++ b/README.md
@@ -22,8 +22,6 @@ guarantee anything.
 - The `gateways` API is only working if your system has a `/proc/net/route` file
 - The `windows` API is non-functional
 
-The following section is taken from the origin netifaces:
-
 ## 2. Usage
 
 For now the API is the same as the original `netifaces`, so please refer to [it](https://github.com/al45tair/netifaces).
@@ -81,8 +79,9 @@ Install using pip:
 `python -m pip install netifaces2`
 
 #### Linux  
-Targeting manylinux_2_28 (requires pip>=20.3)  
-Building also cp36m-manylinux2014 wheels for distros using Python 3.6
+Linux cp37-abi3 wheels are built on manylinux2_17 aka manylinux2014 and require pip>=19.3  
+cp36m-manylinux2_17 wheels are unsupported and are being built only as a fallback
+for systems with only Python 3.6 available.
 
 ## 5. License
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,0 +1,30 @@
+import glob
+
+import nox
+
+
+@nox.session(python=["3.7", "3.8", "3.9", "3.10", "3.11"])
+def tests(session: nox.Session) -> None:
+    """Runs pytest"""
+    wheel = glob.glob("./dist/*whl")[0]
+    session.install(wheel)
+    session.install("pytest", "pytest-cov")
+    session.run(
+        "pytest",
+        "--cov=netifaces",
+        "--cov-config",
+        "pyproject.toml",
+        "--cov-report=",
+        *session.posargs,
+        env={"COVERAGE_FILE": f".coverage.{session.python}"},
+    )
+    session.notify("coverage")
+
+
+@nox.session
+def coverage(session: nox.Session) -> None:
+    """Coverage analysis"""
+    session.install("coverage[toml]")
+    session.run("coverage", "combine")
+    session.run("coverage", "report")
+    session.run("coverage", "erase")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,13 +39,13 @@ dev = [
 ]
 
 [tool.black]
-target-version = ["py311", "py310", "py39", "py38", "py37", "py36"]
+target-version = ["py311", "py310", "py39", "py38", "py37"]
 
 [tool.maturin]
 bindings = "pyo3"
 
 [tool.mypy]
-python_version = "3.6"
+python_version = "3.7"
 exclude = ['venv/.*/*\.py$']
 strict=true
 
@@ -64,4 +64,8 @@ select = [
   "W", # pycodestyle
   "RUF", # ruff
   "I", # isort
+  "PT",   # flake8-pytest-style
 ]
+
+[tool.coverage.report]
+omit = ["_test.py"]

--- a/tests/basic_functionality_test.py
+++ b/tests/basic_functionality_test.py
@@ -1,0 +1,5 @@
+import netifaces
+
+
+def test_interfaces() -> None:
+    assert len(netifaces.interfaces())


### PR DESCRIPTION
nox creates virtualenv per each python version, installs the already built Linux abi wheel and runs pytest and coverage.  

- minor changes in README
- enable pytest lint for ruff