### PR TITLE
Windows fixes and iface indexes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,6 +20,7 @@ repos:
     rev: v0.0.252
     hooks:
       - id: ruff
+        args: [ --fix ]
 
   - repo: https://github.com/abravalheri/validate-pyproject
     rev: v0.12.1

--- a/README.md
+++ b/README.md
@@ -107,10 +107,13 @@ It's then recommended to create a virtual environment and install the package pl
 $ python3 -m venv venv
 $ source venv/bin/activate
 $ python3 -m pip install -e '.[dev]' # This internally runs the Rust compiler
-$ source venv/bin/activate # Re-source the venv, only has to be done after the first time you run pip install
+$ python3 -m pip install pre-commit
+$ source venv/bin/activate # Re-source the venv to pick up new scripts
+$ pre-commit install
 ```
 
-Now you should be able to run the tests:
+To recompile the rust code after making changes, run:
 ```
-$ pytest
+$ python3 -m pip install -e '.[dev]'
 ```
+again.

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ To set up for local development, you will first need to install Rust from [rustu
 It's then recommended to create a virtual environment and install the package plus its dependencies into it:
 ```
 $ python3 -m venv venv
-$ source venv/bin/activate
+$ source venv/bin/activate (or .\venv\Scripts\activate.ps1 with Windows Powershell)
 $ python3 -m pip install -e '.[dev]' # This internally runs the Rust compiler
 $ python3 -m pip install pre-commit
 $ source venv/bin/activate # Re-source the venv to pick up new scripts
@@ -114,6 +114,6 @@ $ pre-commit install
 
 To recompile the rust code after making changes, run:
 ```
-$ python3 -m pip install -e '.[dev]'
+$ python3 -m pip install -e .
 ```
 again.

--- a/README.md
+++ b/README.md
@@ -97,3 +97,20 @@ for systems with only Python 3.6 available.
 ## 5. License
 
 This software is distributed under a MIT license.
+
+## 6. Developing Locally
+
+To set up for local development, you will first need to install Rust from [rustup](https://rustup.rs/).
+
+It's then recommended to create a virtual environment and install the package plus its dependencies into it:
+```
+$ python3 -m venv venv
+$ source venv/bin/activate
+$ python3 -m pip install -e '.[dev]' # This internally runs the Rust compiler
+$ source venv/bin/activate # Re-source the venv, only has to be done after the first time you run pip install
+```
+
+Now you should be able to run the tests:
+```
+$ pytest
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "maturin"
 [project]
 name = "netifaces2"
 description = "Portable network interface information"
-version = "0.1.0"
+version = "0.0.22"
 requires-python = ">=3.7"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "maturin"
 [project]
 name = "netifaces2"
 description = "Portable network interface information"
-version = "0.0.21"
+version = "0.1.0"
 requires-python = ">=3.7"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,9 +6,6 @@ build-backend = "maturin"
 name = "netifaces2"
 description = "Portable network interface information"
 version = "0.0.22"
-
-# bumping CI
-
 requires-python = ">=3.7"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,9 @@ build-backend = "maturin"
 name = "netifaces2"
 description = "Portable network interface information"
 version = "0.0.22"
+
+# bumping CI
+
 requires-python = ">=3.7"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/python/netifaces/__init__.py
+++ b/python/netifaces/__init__.py
@@ -7,7 +7,7 @@ import logging
 import subprocess
 import sys
 from pathlib import Path
-from typing import List, Optional, cast
+from typing import List, Optional, cast, Dict
 
 from .defs import (
     AF_ALG,
@@ -66,7 +66,7 @@ from .defs import (
     InterfaceName,
     InterfaceType,
 )
-from .netifaces import _ifaddresses, _interfaces
+from .netifaces import _ifaddresses, _interfaces, _interfaces_by_index
 
 __all__ = [
     "InterfaceType",
@@ -148,6 +148,16 @@ def interfaces(
     """
 
     return cast(List[InterfaceName], _interfaces(display.value))
+
+
+def interfaces_by_index() -> Dict[int, str]:
+    """
+    List the network interfaces by their index
+
+    :return the list of network interfaces on the machine, with the interface's Index mapped to its Name
+    """
+
+    return cast(Dict[int, str], _interfaces_by_index())
 
 
 def ifaddresses(if_name: str) -> Addresses:

--- a/python/netifaces/__init__.py
+++ b/python/netifaces/__init__.py
@@ -7,7 +7,7 @@ import logging
 import subprocess
 import sys
 from pathlib import Path
-from typing import List, Optional, cast, Dict
+from typing import Dict, List, Optional, cast
 
 from .defs import (
     AF_ALG,
@@ -124,6 +124,21 @@ __all__ = [
 
 
 class InterfaceDisplay(enum.Enum):
+    """
+    Enumeration for ways that interface names can be returned by interfaces()
+    and interfaces_by_index().
+
+    On Windows, there are several different interface name formats used by the
+    OS.  The so-called "name" is a machine-readable UUID, such as
+    '{E5993936-7D91-44DD-84FD-55D909FF2143}'.  The "description" gives the
+    human-readable name of the network adapter, such as 'Realtek PCIe GbE
+    Family Controller'.  This enum is used to select between the two.
+
+    On POSIX platforms, there is really only one format used for interface names:
+    the device name, e.g. "lo" or "eno1".  This format is always returned
+    regardless of the InterfaceDisplay value passed.
+    """
+
     HumanReadable = 0
     MachineReadable = 1
 
@@ -141,7 +156,7 @@ def interfaces(
     """
     List the network interfaces that are available
 
-    :param display: how to display the interface names.
+    :param display: Hint for how to display the interface names.
                     See the `InterfaceDisplay` enum for the values. By default,
                     human-readable.
     :return the list of network interfaces that are available
@@ -150,11 +165,18 @@ def interfaces(
     return cast(List[InterfaceName], _interfaces(display.value))
 
 
-def interfaces_by_index() -> Dict[int, InterfaceName]:
+def interfaces_by_index(
+    display: InterfaceDisplay = InterfaceDisplay.HumanReadable,
+) -> Dict[int, InterfaceName]:
     """
     List the network interfaces by their index
 
-    :return the list of network interfaces on the machine, with the interface's Index mapped to its Name
+    :param display: Hint for how to display the interface names.
+                    See the `InterfaceDisplay` enum for the values. By default,
+                    human-readable.
+
+    :return the list of network interfaces on the machine, with the
+        interface's Index mapped to its Name
     """
 
     return cast(Dict[int, str], _interfaces_by_index())

--- a/python/netifaces/__init__.py
+++ b/python/netifaces/__init__.py
@@ -150,7 +150,7 @@ def interfaces(
     return cast(List[InterfaceName], _interfaces(display.value))
 
 
-def interfaces_by_index() -> Dict[int, str]:
+def interfaces_by_index() -> Dict[int, InterfaceName]:
     """
     List the network interfaces by their index
 

--- a/python/netifaces/__init__.py
+++ b/python/netifaces/__init__.py
@@ -179,7 +179,7 @@ def interfaces_by_index(
         interface's Index mapped to its Name
     """
 
-    return cast(Dict[int, str], _interfaces_by_index())
+    return cast(Dict[int, str], _interfaces_by_index(display.value))
 
 
 def ifaddresses(if_name: str) -> Addresses:

--- a/python/netifaces/defs.py
+++ b/python/netifaces/defs.py
@@ -57,6 +57,7 @@ AF_XDP = 44
 AF_MCTP = 45
 AF_MAX = 46
 AF_LINK = -1000  # Windows Link Layer as defined by netifaces(1)
+AF_INTERFACE_INDEX = -1001  # Magic value for the interface index
 
 
 class InterfaceType(IntEnum):
@@ -110,6 +111,7 @@ class InterfaceType(IntEnum):
     AF_MCTP = AF_MCTP
     AF_MAX = AF_MAX
     AF_LINK = AF_LINK
+    AF_INTERFACE_INDEX = AF_INTERFACE_INDEX
 
 
 InterfaceName = str

--- a/python/netifaces/defs.py
+++ b/python/netifaces/defs.py
@@ -111,7 +111,6 @@ class InterfaceType(IntEnum):
     AF_MCTP = AF_MCTP
     AF_MAX = AF_MAX
     AF_LINK = AF_LINK
-    AF_INTERFACE_INDEX = AF_INTERFACE_INDEX
 
 
 InterfaceName = str

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,5 +1,5 @@
 use pyo3::exceptions::PyTypeError;
-use pyo3::{PyErr, PyResult};
+use pyo3::PyErr;
 use thiserror::Error;
 
 #[derive(Debug, Error)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,10 @@ mod types;
 mod linux;
 
 #[cfg(not(target_family = "windows"))]
-use linux::{linux_ifaddresses as ifaddresses, posix_interfaces as interfaces, posix_interfaces_by_index as interfaces_by_index};
+use linux::{
+    posix_ifaddresses as ifaddresses, posix_interfaces as interfaces,
+    posix_interfaces_by_index as interfaces_by_index,
+};
 
 mod common;
 #[cfg(target_family = "windows")]
@@ -20,7 +23,10 @@ mod win;
 
 use crate::common::InterfaceDisplay;
 #[cfg(target_family = "windows")]
-use win::{windows_ifaddresses as ifaddresses, windows_interfaces as interfaces, windows_interfaces_by_index as interfaces_by_index};
+use win::{
+    windows_ifaddresses as ifaddresses, windows_interfaces as interfaces,
+    windows_interfaces_by_index as interfaces_by_index,
+};
 
 /// Given an u32 in little endian, return the String representation
 /// of it into the colloquial IPV4 string format
@@ -71,8 +77,9 @@ fn _interfaces(interface_display: i32) -> PyResult<Vec<String>> {
     })
 }
 
+#[pyfunction]
 fn _interfaces_by_index(interface_display: i32) -> PyResult<types::IfacesByIndex> {
-    let interface_display = InterfaceDisplay::try_from(interface_display)
+    let interface_display = InterfaceDisplay::try_from(interface_display)?;
     let maybe_ifs = interfaces_by_index(interface_display);
 
     maybe_ifs.map_err(|e| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@ mod win;
 
 use crate::common::InterfaceDisplay;
 #[cfg(target_family = "windows")]
-use win::{windows_ifaddresses as ifaddresses, windows_interfaces as interfaces};
+use win::{windows_ifaddresses as ifaddresses, windows_interfaces as interfaces, windows_interfaces_by_index as interfaces_by_index};
 
 /// Given an u32 in little endian, return the String representation
 /// of it into the colloquial IPV4 string format
@@ -71,6 +71,16 @@ fn _interfaces(interface_display: i32) -> PyResult<Vec<String>> {
     })
 }
 
+fn _interfaces_by_index(interface_display: i32) -> PyResult<types::IfacesByIndex> {
+    let interface_display = InterfaceDisplay::try_from(interface_display)
+    let maybe_ifs = interfaces_by_index(interface_display);
+
+    maybe_ifs.map_err(|e| {
+        let str_message = e.to_string();
+        PyErr::new::<PyRuntimeError, _>(str_message)
+    })
+}
+
 #[pyfunction]
 fn _ifaddresses(if_name: &str) -> PyResult<types::IfAddrs> {
     let maybe_ifaddrs = ifaddresses(if_name);
@@ -84,6 +94,7 @@ fn _ifaddresses(if_name: &str) -> PyResult<types::IfAddrs> {
 #[pymodule]
 fn netifaces(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(_interfaces, m)?)?;
+    m.add_function(wrap_pyfunction!(_interfaces_by_index, m)?)?;
     m.add_function(wrap_pyfunction!(_ifaddresses, m)?)?;
     m.add_function(wrap_pyfunction!(_ip_to_string, m)?)?;
     Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@ mod types;
 mod linux;
 
 #[cfg(not(target_family = "windows"))]
-use linux::{linux_ifaddresses as ifaddresses, linux_interfaces as interfaces};
+use linux::{linux_ifaddresses as ifaddresses, posix_interfaces as interfaces, posix_interfaces_by_index as interfaces_by_index};
 
 mod common;
 #[cfg(target_family = "windows")]

--- a/src/linux.rs
+++ b/src/linux.rs
@@ -30,10 +30,8 @@ pub fn posix_interfaces_by_index(
     let iface_names_idxes = if_nameindex()?;
 
     for iface in &iface_names_idxes {
-        interfaces.insert(
-            iface.index().try_into().unwrap(),
-            iface.name().to_string_lossy().to_string(),
-        );
+        let iface_index = iface.index() as usize;
+        interfaces.insert(iface_index, iface.name().to_string_lossy().to_string());
     }
 
     Ok(interfaces)

--- a/src/linux.rs
+++ b/src/linux.rs
@@ -1,13 +1,14 @@
 use crate::common::InterfaceDisplay;
 use crate::types::{
-    AddrPairs, IfAddrs, ADDR_ADDR, AF_ALG, AF_INET, AF_INET6, AF_NETLINK, AF_PACKET, AF_VSOCK,
+    AddrPairs, IfAddrs, IfacesByIndex, ADDR_ADDR, AF_ALG, AF_INET, AF_INET6, AF_NETLINK, AF_PACKET, AF_VSOCK,
     BROADCAST_ADDR, MASK_ADDR, PEER_ADDR,
 };
 use nix::ifaddrs;
+use nix::net::if_::if_nameindex;
 use std::collections::{HashMap, HashSet};
 use std::fmt::Display;
 
-pub fn linux_interfaces(
+pub fn posix_interfaces(
     _display: InterfaceDisplay,
 ) -> Result<Vec<String>, Box<dyn std::error::Error>> {
     let mut s: HashSet<String> = HashSet::new();
@@ -19,6 +20,18 @@ pub fn linux_interfaces(
     }
 
     Ok(Vec::from_iter(s))
+}
+
+pub fn posix_interfaces_by_index() -> Result<IfacesByIndex, Box<dyn std::error::Error>> {
+    let mut interfaces = IfacesByIndex::new();
+
+    let iface_names_idxes = if_nameindex()?;
+
+    for iface in &iface_names_idxes {
+        interfaces.insert(iface.index(), iface.name().to_string_lossy().to_string());
+    }
+
+    Ok(interfaces)
 }
 
 fn add_to_types_mat(

--- a/src/linux.rs
+++ b/src/linux.rs
@@ -1,7 +1,7 @@
 use crate::common::InterfaceDisplay;
 use crate::types::{
-    AddrPairs, IfAddrs, IfacesByIndex, ADDR_ADDR, AF_ALG, AF_INET, AF_INET6, AF_NETLINK, AF_PACKET, AF_VSOCK,
-    BROADCAST_ADDR, MASK_ADDR, PEER_ADDR,
+    AddrPairs, IfAddrs, IfacesByIndex, ADDR_ADDR, AF_ALG, AF_INET, AF_INET6, AF_NETLINK, AF_PACKET,
+    AF_VSOCK, BROADCAST_ADDR, MASK_ADDR, PEER_ADDR,
 };
 use nix::ifaddrs;
 use nix::net::if_::if_nameindex;
@@ -22,7 +22,9 @@ pub fn posix_interfaces(
     Ok(Vec::from_iter(s))
 }
 
-pub fn posix_interfaces_by_index() -> Result<IfacesByIndex, Box<dyn std::error::Error>> {
+pub fn posix_interfaces_by_index(
+    _display: InterfaceDisplay,
+) -> Result<IfacesByIndex, Box<dyn std::error::Error>> {
     let mut interfaces = IfacesByIndex::new();
 
     let iface_names_idxes = if_nameindex()?;
@@ -52,7 +54,7 @@ fn add_to_types_mat(
     e[l - 1].insert(class.to_string(), format!("{addr}"));
 }
 
-pub fn linux_ifaddresses(if_name: &str) -> Result<IfAddrs, Box<dyn std::error::Error>> {
+pub fn posix_ifaddresses(if_name: &str) -> Result<IfAddrs, Box<dyn std::error::Error>> {
     let mut types_mat: HashMap<i32, Vec<AddrPairs>> = HashMap::new();
     let if_addrs = nix::ifaddrs::getifaddrs()?;
 

--- a/src/linux.rs
+++ b/src/linux.rs
@@ -30,7 +30,10 @@ pub fn posix_interfaces_by_index(
     let iface_names_idxes = if_nameindex()?;
 
     for iface in &iface_names_idxes {
-        interfaces.insert(iface.index(), iface.name().to_string_lossy().to_string());
+        interfaces.insert(
+            iface.index().try_into().unwrap(),
+            iface.name().to_string_lossy().to_string(),
+        );
     }
 
     Ok(interfaces)

--- a/src/types.rs
+++ b/src/types.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 
 pub type AddrPairs = HashMap<String, String>;
 pub type IfAddrs = HashMap<i32, Vec<AddrPairs>>;
+pub type IfacesByIndex = HashMap<u32, String>;
 
 pub const ADDR_ADDR: &str = "addr";
 pub const MASK_ADDR: &str = "mask";

--- a/src/types.rs
+++ b/src/types.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 
 pub type AddrPairs = HashMap<String, String>;
 pub type IfAddrs = HashMap<i32, Vec<AddrPairs>>;
-pub type IfacesByIndex = HashMap<u32, String>;
+pub type IfacesByIndex = HashMap<usize, String>;
 
 pub const ADDR_ADDR: &str = "addr";
 pub const MASK_ADDR: &str = "mask";

--- a/src/win.rs
+++ b/src/win.rs
@@ -361,11 +361,12 @@ pub fn windows_interfaces_by_index(
         Ok(win_ifaces) => {
             let mut interfaces = types::IfacesByIndex::new();
             for win_iface in win_ifaces {
-                if display == InterfaceDisplay::HumanReadable {
-                    interfaces.insert(win_iface.index, win_iface.description);
-                } else {
-                    interfaces.insert(win_iface.index, win_iface.name);
-                }
+                let value = match display {
+                    InterfaceDisplay::HumanReadable => win_iface.description,
+                    InterfaceDisplay::MachineReadable => win_iface.name,
+                };
+
+                interfaces.insert(win_iface.index, value);
             }
             Ok(interfaces)
         }

--- a/src/win.rs
+++ b/src/win.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code)]
 use crate::common::InterfaceDisplay;
-use crate::{mac_to_string, types};
 use crate::types::{IfAddrs, ADDR_ADDR, AF_INET, MASK_ADDR};
+use crate::{mac_to_string, types};
 use std::alloc::{alloc, dealloc, Layout};
 use std::collections::HashMap;
 use std::error::Error;
@@ -63,7 +63,6 @@ fn win_ip_addr_list_to_vec(ip: IP_ADDR_STRING) -> Vec<WinIpInfo> {
     let mut r = vec![];
 
     loop {
-
         let info = WinIpInfo {
             ip_address: win_adapter_name_to_string(&ip.IpAddress.String),
             mask: win_adapter_name_to_string(&ip.IpMask.String),
@@ -353,22 +352,23 @@ pub fn windows_interfaces(display: InterfaceDisplay) -> Result<Vec<String>, Box<
 }
 
 /// List all the network interfaces available on the system by their indexes
-pub fn windows_interfaces_by_index(display: InterfaceDisplay) -> Result<types::IfacesByIndex, Box<dyn std::error::Error>> {
+pub fn windows_interfaces_by_index(
+    display: InterfaceDisplay,
+) -> Result<types::IfacesByIndex, Box<dyn std::error::Error>> {
     let interfaces = win_explore_adapters();
 
     match interfaces {
         Ok(win_ifaces) => {
             let mut interfaces = types::IfacesByIndex::new();
             for win_iface in win_ifaces {
-                if display==InterfaceDisplay::HumanReadable {
+                if display == InterfaceDisplay::HumanReadable {
                     interfaces.insert(win_iface.index, win_iface.description);
-                }
-                else {
+                } else {
                     interfaces.insert(win_iface.index, win_iface.name);
                 }
             }
             Ok(interfaces)
         }
-        Err(err) => Err(err)
+        Err(err) => Err(err),
     }
 }

--- a/src/win.rs
+++ b/src/win.rs
@@ -68,7 +68,7 @@ fn win_ip_addr_list_to_vec(ip: IP_ADDR_STRING) -> Vec<WinIpInfo> {
             mask: win_adapter_name_to_string(&ip.IpMask.String),
         };
 
-        // In my testing, GetAdaptersInfo returns an IP of "0.0.0.0" when the interface
+        // In testing, GetAdaptersInfo returns an IP of "0.0.0.0" when the interface
         // is down and does not have an IP assigned.  So only include the IP if it's
         // not 0.0.0.0
         if info.ip_address != "0.0.0.0" {

--- a/tests/basic_functionality_test.py
+++ b/tests/basic_functionality_test.py
@@ -71,6 +71,9 @@ def test_interface_display_formats_windows() -> None:
     assert re.fullmatch(uuid_regex, human_readable_iface0) is None
 
 
+@pytest.mark.skipif(
+    platform.system() == "Windows", reason="Does not pass yet on Windows"
+)  # type: ignore[misc]
 def test_loopback_addr_is_returned() -> None:
     """
     Test that the loopback address is returned in the lists of addresses

--- a/tests/basic_functionality_test.py
+++ b/tests/basic_functionality_test.py
@@ -6,8 +6,8 @@ def test_interfaces_returns_something() -> None:
 
 
 def test_interfaces_by_index_returns_same_interface_list() -> None:
-    # Interface indices are difficult to verify, but we can at least check that we get the same set
-    # of interfaces in both these functions
+    # Interface indices are difficult to verify, but we can at least check that we get
+    # the same set of interfaces in both these functions
     assert set(netifaces.interfaces_by_index().values()) == set(netifaces.interfaces())
 
 
@@ -55,20 +55,27 @@ def test_loopback_addr_is_returned() -> None:
 
         if netifaces.AF_INET in address_table:
             for ipv4_settings in address_table[netifaces.AF_INET]:
-                print(f"Loopback test: Considering iface {interface} IPv4 address {ipv4_settings['addr']}")
+                print(
+                    f"Loopback test: Considering iface {interface} IPv4 address "
+                    f"{ipv4_settings['addr']}"
+                )
                 if ipv4_settings["addr"] == "127.0.0.1":
                     print("Loopback IPv4 found!")
                     loopback_ipv4_found = True
 
         if netifaces.AF_INET6 in address_table:
             for ipv6_settings in address_table[netifaces.AF_INET6]:
-                print(f"Loopback test: Considering iface {interface} IPv6 address {ipv6_settings['addr']}")
+                print(
+                    f"Loopback test: Considering iface {interface} IPv6 address "
+                    f"{ipv6_settings['addr']}"
+                )
                 if ipv6_settings["addr"] == "::1":
                     print("Loopback IPv6 found!")
                     loopback_ipv6_found = True
 
     assert loopback_ipv4_found
     assert loopback_ipv6_found
+
 
 def test_all_ifaces_have_ipv4() -> None:
     """

--- a/tests/basic_functionality_test.py
+++ b/tests/basic_functionality_test.py
@@ -41,6 +41,10 @@ def test_has_link_layer() -> None:
     assert has_any_link, "Test failure; no AF_PACKET address of any kind found"
 
 
+##@pytest.mark.skipif(platform.system() != "Windows", reason="Windows only")
+##def test_interface_display_formats
+
+
 def test_loopback_addr_is_returned() -> None:
     """
     Test that the loopback address is returned in the lists of addresses
@@ -54,7 +58,7 @@ def test_loopback_addr_is_returned() -> None:
         address_table = netifaces.ifaddresses(interface)
 
         if netifaces.AF_INET in address_table:
-            for ipv4_settings in address_table[netifaces.AF_INET]:
+            for ipv4_settings in address_table[netifaces.InterfaceType.AF_INET]:
                 print(
                     f"Loopback test: Considering iface {interface} IPv4 address "
                     f"{ipv4_settings['addr']}"
@@ -64,7 +68,7 @@ def test_loopback_addr_is_returned() -> None:
                     loopback_ipv4_found = True
 
         if netifaces.AF_INET6 in address_table:
-            for ipv6_settings in address_table[netifaces.AF_INET6]:
+            for ipv6_settings in address_table[netifaces.InterfaceType.AF_INET6]:
                 print(
                     f"Loopback test: Considering iface {interface} IPv6 address "
                     f"{ipv6_settings['addr']}"
@@ -87,5 +91,5 @@ def test_all_ifaces_have_ipv4() -> None:
     for interface in netifaces.interfaces():
         address_table = netifaces.ifaddresses(interface)
         if netifaces.AF_INET in address_table:
-            for ipv4_settings in address_table[netifaces.AF_INET]:
+            for ipv4_settings in address_table[netifaces.InterfaceType.AF_INET]:
                 assert ipv4_settings["addr"] != "0.0.0.0"

--- a/tests/basic_functionality_test.py
+++ b/tests/basic_functionality_test.py
@@ -45,9 +45,7 @@ def test_has_link_layer() -> None:
     assert has_any_link, "Test failure; no AF_PACKET address of any kind found"
 
 
-@pytest.mark.skipif(
-    platform.system() != "Windows", reason="Windows only"
-)  # type: ignore[misc]
+@pytest.mark.skipif(platform.system() != "Windows", reason="Windows only")  # type: ignore[misc]
 def test_interface_display_formats_windows() -> None:
     """
     Check that the InterfaceDisplay argument can be used to select between a UUID
@@ -57,23 +55,17 @@ def test_interface_display_formats_windows() -> None:
     uuid_regex = r"{[-A-F0-9]+}"
 
     # The machine readable interface should look like a UUID string
-    machine_readable_iface0 = netifaces.interfaces(
-        netifaces.InterfaceDisplay.MachineReadable
-    )[0]
+    machine_readable_iface0 = netifaces.interfaces(netifaces.InterfaceDisplay.MachineReadable)[0]
     print(f"Machine readable name of interface 0 is: {machine_readable_iface0}")
     assert re.fullmatch(uuid_regex, machine_readable_iface0) is not None
 
     # The human readable interface should NOT look like a UUID
-    human_readable_iface0 = netifaces.interfaces(
-        netifaces.InterfaceDisplay.HumanReadable
-    )[0]
+    human_readable_iface0 = netifaces.interfaces(netifaces.InterfaceDisplay.HumanReadable)[0]
     print(f"Human readable name of interface 0 is: {human_readable_iface0}")
     assert re.fullmatch(uuid_regex, human_readable_iface0) is None
 
 
-@pytest.mark.skipif(
-    platform.system() == "Windows", reason="Does not pass yet on Windows"
-)  # type: ignore[misc]
+@pytest.mark.skipif(platform.system() == "Windows", reason="Does not pass yet on Windows")  # type: ignore[misc]
 def test_loopback_addr_is_returned() -> None:
     """
     Test that the loopback address is returned in the lists of addresses
@@ -88,20 +80,14 @@ def test_loopback_addr_is_returned() -> None:
 
         if netifaces.AF_INET in address_table:
             for ipv4_settings in address_table[netifaces.InterfaceType.AF_INET]:
-                print(
-                    f"Loopback test: Considering iface {interface} IPv4 address "
-                    f"{ipv4_settings['addr']}"
-                )
+                print(f"Loopback test: Considering iface {interface} IPv4 address " f"{ipv4_settings['addr']}")
                 if ipv4_settings["addr"] == "127.0.0.1":
                     print("Loopback IPv4 found!")
                     loopback_ipv4_found = True
 
         if netifaces.AF_INET6 in address_table:
             for ipv6_settings in address_table[netifaces.InterfaceType.AF_INET6]:
-                print(
-                    f"Loopback test: Considering iface {interface} IPv6 address "
-                    f"{ipv6_settings['addr']}"
-                )
+                print(f"Loopback test: Considering iface {interface} IPv6 address " f"{ipv6_settings['addr']}")
                 if ipv6_settings["addr"] == "::1":
                     print("Loopback IPv6 found!")
                     loopback_ipv6_found = True

--- a/tests/basic_functionality_test.py
+++ b/tests/basic_functionality_test.py
@@ -1,4 +1,8 @@
+import platform
+import re
+
 import netifaces
+import pytest
 
 
 def test_interfaces_returns_something() -> None:
@@ -41,8 +45,30 @@ def test_has_link_layer() -> None:
     assert has_any_link, "Test failure; no AF_PACKET address of any kind found"
 
 
-##@pytest.mark.skipif(platform.system() != "Windows", reason="Windows only")
-##def test_interface_display_formats
+@pytest.mark.skipif(
+    platform.system() != "Windows", reason="Windows only"
+)  # type: ignore[misc]
+def test_interface_display_formats_windows() -> None:
+    """
+    Check that the InterfaceDisplay argument can be used to select between a UUID
+    and a human readable name
+    """
+
+    uuid_regex = r"{[-A-F0-9]+}"
+
+    # The machine readable interface should look like a UUID string
+    machine_readable_iface0 = netifaces.interfaces(
+        netifaces.InterfaceDisplay.MachineReadable
+    )[0]
+    print(f"Machine readable name of interface 0 is: {machine_readable_iface0}")
+    assert re.fullmatch(uuid_regex, machine_readable_iface0) is not None
+
+    # The human readable interface should NOT look like a UUID
+    human_readable_iface0 = netifaces.interfaces(
+        netifaces.InterfaceDisplay.HumanReadable
+    )[0]
+    print(f"Human readable name of interface 0 is: {human_readable_iface0}")
+    assert re.fullmatch(uuid_regex, human_readable_iface0) is None
 
 
 def test_loopback_addr_is_returned() -> None:

--- a/win_ip_helper/src/main.rs
+++ b/win_ip_helper/src/main.rs
@@ -6,7 +6,6 @@ use windows::Win32::Foundation::{ERROR_BUFFER_OVERFLOW, WIN32_ERROR};
 use windows::Win32::NetworkManagement::IpHelper;
 use windows::Win32::NetworkManagement::IpHelper::IP_ADAPTER_INFO;
 
-
 fn adapter_info_size_required() -> Result<u32, WIN32_ERROR> {
     let mut size: u32 = 0;
     unsafe {
@@ -29,5 +28,7 @@ fn main() {
         }
     };
     let number_of_entries = (size as usize) / size_of::<IP_ADAPTER_INFO>();
-    println!("To get the adapter's table, {size} bytes are required, or {number_of_entries} structures.");
+    println!(
+        "To get the adapter's table, {size} bytes are required, or {number_of_entries} structures."
+    );
 }


### PR DESCRIPTION
Hello!  After what we talked about last week, I prototyped a way to add interface indices to the netifaces2 API.  Along the way, I also found some bugs on Windows and am working through fixing them.

Changes made so far:
- Add a new `netifaces.interfaces_by_index()` API function.  This is similar to `netifaces.interfaces()`, except that it returns a dictionary of interface index to interface name instead of just the interface name.
- Implement interfaces_by_index() for Windows and POSIX in the rust code.  This is my first time ever writing any Rust, so please be gentle and let me know how I messed up :P
- Add regression tests for two issues I noticed on Windows
- Add "Developing Locally" section to the README.  These are the commands I figured out to develop this project locally, no idea if they're the correct ones...
- I could NOT resist renaming some of the linux_xxx functions to posix_xxx ones, because I'm kinda triggered by the fact that they say linux but work for mac as well
- Bugfix: On Windows, IPv6 addresses were returned under the wrong key in the ifaddrs() dict
- Bugfix: On Windows, some interfaces would report being assigned 0.0.0.0 as an IP, when in actual fact they did not have an IP address at all