### PR TITLE
Rewrite Windows implementation to use GetAdaptersAddresses via Rust crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,6 +33,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
+name = "get_adapters_addresses"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa6d768b8f11cc8995f5c3f3f51660a50f8fa807eaeb83632d9afb4d42b0e493"
+dependencies = [
+ "thiserror",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "indoc"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -82,6 +92,7 @@ dependencies = [
 name = "netifaces"
 version = "0.1.0"
 dependencies = [
+ "get_adapters_addresses",
  "log",
  "nix",
  "pyo3",
@@ -128,7 +139,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-sys",
+ "windows-sys 0.36.1",
 ]
 
 [[package]]
@@ -296,12 +307,12 @@ version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0286ba339aa753e70765d521bb0242cc48e1194562bfa2a2ad7ac8a6de28f5d5"
 dependencies = [
- "windows_aarch64_gnullvm",
+ "windows_aarch64_gnullvm 0.42.0",
  "windows_aarch64_msvc 0.42.0",
  "windows_i686_gnu 0.42.0",
  "windows_i686_msvc 0.42.0",
  "windows_x86_64_gnu 0.42.0",
- "windows_x86_64_gnullvm",
+ "windows_x86_64_gnullvm 0.42.0",
  "windows_x86_64_msvc 0.42.0",
 ]
 
@@ -319,10 +330,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
 name = "windows_aarch64_gnullvm"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41d2aa71f6f0cbe00ae5167d90ef3cfe66527d6f613ca78ac8024c3ccab9a19e"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -337,6 +378,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
 
 [[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
 name = "windows_i686_gnu"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -347,6 +394,12 @@ name = "windows_i686_gnu"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbeae19f6716841636c28d695375df17562ca208b2b7d0dc47635a50ae6c5de7"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -361,6 +414,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -373,10 +432,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf7b1b21b5362cbc318f686150e5bcea75ecedc74dd157d874d754a2ca44b0ed"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09d525d2ba30eeb3297665bd434a54297e4170c7f1a44cad4ef58095b4cd2028"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -389,3 +460,9 @@ name = "windows_x86_64_msvc"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ windows = { version = "0.42.0", features = [
     "Win32_NetworkManagement_NetManagement",
     "Win32_NetworkManagement_IpHelper",
     "Win32_Networking"] }
+get_adapters_addresses = "0.1.1"
 
 [dependencies.pyo3]
 version = "0.17.1"

--- a/README.md
+++ b/README.md
@@ -76,8 +76,15 @@ to be platform independent. This has the nice effect of abstracting the OS when
 accessing the information of a network layer. However after consideration, it
 does not feel like the right place to provide abstraction. If you update your
 project's dependencies to this version of `netifaces`, be wary of this change.
-For instance, on linux you may need to replace `AF_LINK` with `AF_PACKET` to get
-mac addresses.
+
+Also note that in netifaces-2, the AF_ constants no longer share the same integer value
+as their equivalents from the `socket` module.  This means that code which uses the
+two sets of constants interchangeably may have to be updated.
+
+So that type annotations can help with this, netifaces provides the `netifaces.InterfaceType`
+enum for its own interface types.  All netifaces results are annotated using this type.
+You should use values like `netifaces.InterfaceType.AF_INET6` instead of `netifaces.AF_INET6`
+where possible so that a type checker can help catch issues with using the incorrect constants.
 
 In the future, an extra API will allow accessing a specific layer's information
 by querying for it, without using the platform's constant.

--- a/examples/netifaces2_ip_addr.py
+++ b/examples/netifaces2_ip_addr.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+
+"""
+Rudimentary replica of the `ip addr` tool, implemented using netifaces2.
+
+This can be used when developing netifaces as a way to sanity check its output by comparing
+to the interfaces listed by the native tool.
+"""
+
+import ipaddress
+from typing import Dict
+
+import netifaces
+from netifaces import InterfaceType
+
+
+def netmask_string_to_prefix_len_v6(netmask: str) -> int:
+    """
+    Sadly the ipaddress library does not support converting an IPv6 subnet mask into a prefix length
+    So we have to do this one manually.
+    """
+
+    # From https://stackoverflow.com/a/33533007/7083698
+    bit_count = [
+        0,
+        0x8000,
+        0xC000,
+        0xE000,
+        0xF000,
+        0xF800,
+        0xFC00,
+        0xFE00,
+        0xFF00,
+        0xFF80,
+        0xFFC0,
+        0xFFE0,
+        0xFFF0,
+        0xFFF8,
+        0xFFFC,
+        0xFFFE,
+        0xFFFF,
+    ]
+
+    count = 0
+    for w in netmask.split(":"):
+        if not w or int(w, 16) == 0:
+            break
+        count += bit_count.index(int(w, 16))
+
+    return count
+
+
+def print_ip_addr_entry(
+    ip_addr_entry: Dict[netifaces.defs.AddressType, netifaces.defs.Address], iface_type: InterfaceType
+) -> None:
+    """
+    Print a single IP address (v4 or v6) to the console.
+    """
+
+    print(f"    inet{'6' if iface_type == InterfaceType.AF_INET6 else ''} {ip_addr_entry['addr']}", end="")
+
+    # Print peer address if it exists
+    if "peer" in ip_addr_entry:
+        print(f" peer {ip_addr_entry['peer']}")
+
+    # If the netmask is available, compute the prefix.
+    # Per here: https://serverfault.com/questions/998915/netmask-for-point-to-point-ip-address
+    # the prefix length is traditionally printed on the peer address when it exists.
+    if "mask" in ip_addr_entry:
+        if iface_type == InterfaceType.AF_INET:
+            # We can use ipaddress's network class to get the integer prefix from an address and subnet
+            iface_with_mask = ipaddress.IPv4Network((ip_addr_entry["addr"] + "/" + ip_addr_entry["mask"]), strict=False)
+            prefix_len = iface_with_mask.prefixlen
+        else:
+            prefix_len = netmask_string_to_prefix_len_v6(ip_addr_entry["mask"])
+
+        print(f"/{prefix_len}", end="")
+
+    # Print broadcast address if it exists
+    if "broadcast" in ip_addr_entry:
+        print(f" brd {ip_addr_entry['broadcast']}")
+
+    print("")
+
+
+def print_ifaces() -> None:
+    # First, enumerate all the interfaces on the machine
+    sorted_ifaces = dict(sorted(netifaces.interfaces_by_index(netifaces.InterfaceDisplay.HumanReadable).items()))
+
+    for index, name in sorted_ifaces.items():
+        print(f"{index}: {name}")
+
+        # Get addresses of this interface at each level
+        addrs = netifaces.ifaddresses(name)
+
+        # Print mac addresses
+        if InterfaceType.AF_PACKET in addrs:
+            for mac_addr_entry in addrs[InterfaceType.AF_PACKET]:
+                print(f"    link/ether {mac_addr_entry['addr']}")
+
+        # Print IPv4 addresses
+        if InterfaceType.AF_INET in addrs:
+            for ip_addr_entry in addrs[InterfaceType.AF_INET]:
+                print_ip_addr_entry(ip_addr_entry, InterfaceType.AF_INET)
+
+        # Print IPv6 addresses
+        if InterfaceType.AF_INET6 in addrs:
+            for ip_addr_entry in addrs[InterfaceType.AF_INET6]:
+                print_ip_addr_entry(ip_addr_entry, InterfaceType.AF_INET6)
+
+
+if __name__ == "__main__":
+    print_ifaces()

--- a/examples/netifaces2_ip_addr.py
+++ b/examples/netifaces2_ip_addr.py
@@ -61,7 +61,7 @@ def print_ip_addr_entry(
 
     # Print peer address if it exists
     if "peer" in ip_addr_entry:
-        print(f" peer {ip_addr_entry['peer']}")
+        print(f" peer {ip_addr_entry['peer']}", end="")
 
     # If the netmask is available, compute the prefix.
     # Per here: https://serverfault.com/questions/998915/netmask-for-point-to-point-ip-address
@@ -78,7 +78,7 @@ def print_ip_addr_entry(
 
     # Print broadcast address if it exists
     if "broadcast" in ip_addr_entry:
-        print(f" brd {ip_addr_entry['broadcast']}")
+        print(f" brd {ip_addr_entry['broadcast']}", end="")
 
     print("")
 
@@ -96,7 +96,10 @@ def print_ifaces() -> None:
         # Print mac addresses
         if InterfaceType.AF_PACKET in addrs:
             for mac_addr_entry in addrs[InterfaceType.AF_PACKET]:
-                print(f"    link/ether {mac_addr_entry['addr']}")
+                print(f"    link/ether {mac_addr_entry['addr']}", end="")
+                if "broadcast" in mac_addr_entry:
+                    print(f" brd {mac_addr_entry['broadcast']}", end="")
+                print("")
 
         # Print IPv4 addresses
         if InterfaceType.AF_INET in addrs:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "maturin"
 [project]
 name = "netifaces2"
 description = "Portable network interface information"
-version = "0.0.22"
+version = "0.1.0"
 requires-python = ">=3.7"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/python/netifaces/defs.py
+++ b/python/netifaces/defs.py
@@ -56,8 +56,16 @@ AF_SMC = 43
 AF_XDP = 44
 AF_MCTP = 45
 AF_MAX = 46
-AF_LINK = -1000  # Windows Link Layer as defined by netifaces(1)
-AF_INTERFACE_INDEX = -1001  # Magic value for the interface index
+
+# Different OSs use different terms to refer to the MAC layer address -- some (Windows)
+# use AF_LINK only, some (Linux) use AF_PACKET only, and still others (Mac?) use
+# both.  On systems which have both, they aren't *exactly* the same thing, but they
+# are pretty close, and currently the POSIX rust layer only processes AF_PACKET anyway.
+# For that reason, we define AF_LINK as an alias of AF_PACKET.  This is likely best
+# for compatibility with old netifaces code, and is pretty similar to how
+# netifaces 1 does it:
+# https://github.com/al45tair/netifaces/blob/master/netifaces.c#L235
+AF_LINK = AF_PACKET
 
 
 class InterfaceType(IntEnum):

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,12 +1,5 @@
 use pyo3::exceptions::PyTypeError;
 use pyo3::PyErr;
-use thiserror::Error;
-
-#[derive(Debug, Error)]
-pub enum NetifacesError {
-    #[error("Failed to use a system function (module {0}, error code {1})")]
-    SystemErrorCode(String, u32),
-}
 
 /// Controls what is the interface name returned to the user.
 pub enum InterfaceDisplay {

--- a/src/win.rs
+++ b/src/win.rs
@@ -56,7 +56,7 @@ fn ifaddresses_mac(
             // format that we need to be compatible with netifaces.  So we have to do a bit
             // of string munging.
             let mac_str_hyphens = format!("{}", phys_addr);
-            let mac_str = mac_str_hyphens.replace("-", ":");
+            let mac_str = mac_str_hyphens.replace("-", ":").to_lowercase();
 
             let m = HashMap::from([(ADDR_ADDR.to_string(), mac_str)]);
             macs.push(m);
@@ -74,7 +74,7 @@ pub fn windows_ifaddresses(if_name: &str) -> Result<IfAddrs, Box<dyn std::error:
 
     let adapter_addresses = get_adapters_addresses::AdaptersAddresses::try_new(
         get_adapters_addresses::Family::Unspec,
-        *get_adapters_addresses::Flags::default().include_prefix(),
+        get_adapters_addresses::Flags::default(), // Note: would really like to use include_prefix() here, but there's no way to get the prefix
     )?;
 
     // first find the interface, matching either the description or the name

--- a/tests/basic_functionality_test.py
+++ b/tests/basic_functionality_test.py
@@ -19,9 +19,16 @@ def test_can_lookup_by_either_name() -> None:
     # Test that it's possible to look up the ifaddresses of an interface
     # by either its machine readable or its human readable name
 
-    # Choose an arbitrary interface
-    iface_human_readable = netifaces.interfaces(netifaces.InterfaceDisplay.HumanReadable)[0]
-    iface_machine_readable = netifaces.interfaces(netifaces.InterfaceDisplay.MachineReadable)[0]
+    # Choose an arbitrary interface by its index.
+    # Use indices because the network interface list might not always be sorted the same between
+    # multiple calls.
+    ifaces_human_readable = netifaces.interfaces_by_index(netifaces.InterfaceDisplay.HumanReadable)
+    arbitrary_iface_idx = next(iter(ifaces_human_readable.keys()))
+
+    iface_human_readable = ifaces_human_readable[arbitrary_iface_idx]
+    iface_machine_readable = netifaces.interfaces_by_index(netifaces.InterfaceDisplay.MachineReadable)[
+        arbitrary_iface_idx
+    ]
 
     assert netifaces.ifaddresses(iface_human_readable) == netifaces.ifaddresses(iface_machine_readable)
 

--- a/tests/basic_functionality_test.py
+++ b/tests/basic_functionality_test.py
@@ -15,6 +15,17 @@ def test_interfaces_by_index_returns_same_interface_list() -> None:
     assert set(netifaces.interfaces_by_index().values()) == set(netifaces.interfaces())
 
 
+def test_can_lookup_by_either_name() -> None:
+    # Test that it's possible to look up the ifaddresses of an interface
+    # by either its machine readable or its human readable name
+
+    # Choose an arbitrary interface
+    iface_human_readable = netifaces.interfaces(netifaces.InterfaceDisplay.HumanReadable)[0]
+    iface_machine_readable = netifaces.interfaces(netifaces.InterfaceDisplay.MachineReadable)[0]
+
+    assert netifaces.ifaddresses(iface_human_readable) == netifaces.ifaddresses(iface_machine_readable)
+
+
 def test_has_ipv4_or_ipv6() -> None:
     has_any_ip = False
 
@@ -65,7 +76,6 @@ def test_interface_display_formats_windows() -> None:
     assert re.fullmatch(uuid_regex, human_readable_iface0) is None
 
 
-@pytest.mark.skipif(platform.system() == "Windows", reason="Does not pass yet on Windows")  # type: ignore[misc]
 def test_loopback_addr_is_returned() -> None:
     """
     Test that the loopback address is returned in the lists of addresses


### PR DESCRIPTION
The Windows implementation in the main branch has one significant issue remaining which prevents me from using it: it does not return the loopback interface in the list of interfaces.  This is a big problem for `multicast_expert` as it prevents opening a socket on the loopback interface!

This PR attempts to fix this issue by changing the source of interface data on Windows to the GetAdaptersAddresses() function instead of the GetAdaptersInfo().  Happily, somebody already implemented a [rust crate](https://lib.rs/crates/get_adapters_addresses) that wraps this function in a safe wrapper, and this let me rewrite the windows code to be a lot simpler.  Sadly, there was one feature I had to drop (netmasks and broadcast addresses) as it is not currently supported by the wrapper.    However, I think that overall using the wrapper is the way to go as it makes the Windows version of the code way simpler and hopefully more bug immune (fingers crossed it fixes that weird memory issue that guy was seeing!).

Aside from this, I also made two other significant changes which I think should be very helpful for users.

First of all, I added a new script under examples which replicates the `ip addr` command using the netifaces-2 API.  This should be a useful example of how to use netifaces, and it lets one easily sanity check the library on any machine by comparing the output of the script to that of `ifconfig /all` or `ip addr`.

Second of all, I changed up the situation with the `AF_LINK` constant.  Previously, you had to pass `AF_LINK` on Windows to get the mac address and `AF_PACKET` on posix platforms.  This seems like a really annoying trap for users, as it would be easy to use one constat or the other and then hey, your code is broken on Windows/Posix.  To mitigate this, I simply assigned those constants to be the same value.  This should work OK with legacy code while being more intuitive for users.

Hope this change looks useful, and I hope you agree that this is worth increasing the version number to 0.1.0 as the Windows implementation is now a lot cleaner!

P.S. going forward, we really need to either get in touch with the author of the `get_adapters_addresses` crate or fork it ourselves, because it's quite irritating that some of the functionality we need is not exposed in the wrapper.  I already submitted one feature request but haven't heard back.