### PR TITLE
Fix Rust build on OpenBSD

### DIFF
--- a/src/linux.rs
+++ b/src/linux.rs
@@ -1,8 +1,10 @@
 use crate::common::InterfaceDisplay;
 use crate::types::{
-    AddrPairs, IfAddrs, IfacesByIndex, ADDR_ADDR, AF_ALG, AF_INET, AF_INET6, AF_NETLINK, AF_PACKET,
-    AF_VSOCK, BROADCAST_ADDR, MASK_ADDR, PEER_ADDR,
+    AddrPairs, IfAddrs, IfacesByIndex, ADDR_ADDR, AF_INET, AF_INET6, AF_PACKET, BROADCAST_ADDR,
+    MASK_ADDR, PEER_ADDR,
 };
+#[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "openbsd")))]
+use crate::types::{AF_ALG, AF_NETLINK, AF_VSOCK};
 use crate::NetifacesError;
 use nix::ifaddrs;
 use nix::net::if_::if_nameindex;
@@ -83,12 +85,12 @@ pub fn posix_ifaddresses(if_name: &str) -> Result<IfAddrs, Box<dyn std::error::E
                     add_to_types_mat(AF_PACKET, mac_addr, name, &mut types_mat, &mut any);
                 }
 
-                #[cfg(not(any(target_os = "ios", target_os = "macos")))]
+                #[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "openbsd")))]
                 if let Some(net_link) = address.as_netlink_addr() {
                     add_to_types_mat(AF_NETLINK, net_link, name, &mut types_mat, &mut any);
                 }
 
-                #[cfg(not(any(target_os = "ios", target_os = "macos")))]
+                #[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "openbsd")))]
                 if let Some(vsock_addr) = address.as_vsock_addr() {
                     add_to_types_mat(AF_VSOCK, vsock_addr, name, &mut types_mat, &mut any);
                 }
@@ -97,7 +99,7 @@ pub fn posix_ifaddresses(if_name: &str) -> Result<IfAddrs, Box<dyn std::error::E
                     add_to_types_mat(AF_INET, &inet_addr.ip(), name, &mut types_mat, &mut any);
                 }
 
-                #[cfg(not(any(target_os = "ios", target_os = "macos")))]
+                #[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "openbsd")))]
                 if let Some(alg_addr) = address.as_alg_addr() {
                     add_to_types_mat(AF_ALG, alg_addr, name, &mut types_mat, &mut any);
                 }
@@ -122,7 +124,11 @@ pub fn posix_ifaddresses(if_name: &str) -> Result<IfAddrs, Box<dyn std::error::E
 #[cfg(any(target_os = "ios", target_os = "macos"))]
 const SIOCGIFFLAGS: libc::c_ulong = 0xc0206911; // extracted from macos headers
 
-#[cfg(not(any(target_os = "ios", target_os = "macos")))]
+// SIOCGIFFLAGS constant currently not available from the libc crate on OpenBSD
+#[cfg(target_os = "openbsd")]
+const SIOCGIFFLAGS: libc::c_ulong = 0xc0206911; // extracted from sys/sockio.h
+
+#[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "openbsd")))]
 const SIOCGIFFLAGS: libc::c_ulong = libc::SIOCGIFFLAGS;
 
 /// Read the flags from an interface using the SIOCGIFFLAGS


### PR DESCRIPTION
- define `SIOCGIFFLAGS` const, value from OpenBSD include `sys/sockio.h`
- add case `target_os="openbsd"` for `as_netlink_addr`, `as_vsock_addr` and `as_alg_addr `functions.

Fix #42 

---
**Build OK** on OpenBSD current/amd64 with Rust 1.86.0
```sh
$ cargo build -v
(...)
   Compiling netifaces v0.1.0 (/home/fox/dev/netifaces-2.git)                                                                                                                                                                                                                     
(...)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.71s

$ ls -l target/debug/
total 10440
drwxr-xr-x  28 fox  fox     1024 May  2 10:11 build
drwxr-xr-x   2 fox  fox    11264 May  2 10:25 deps
drwxr-xr-x   2 fox  fox      512 May  2 10:11 examples
drwxr-xr-x   5 fox  fox      512 May  2 10:23 incremental
-rw-r--r--   1 fox  fox      231 May  2 10:25 libnetifaces.d
-rwxr-xr-x   2 fox  fox  5297520 May  2 10:25 libnetifaces.so
```