### PR TITLE
Support for gateways() on OpenBSD

### DIFF
--- a/python/netifaces/__init__.py
+++ b/python/netifaces/__init__.py
@@ -209,6 +209,20 @@ def _ip_tool_path() -> Optional[str]:
     return ip
 
 
+def _netstat_bsd_tool_path() -> Optional[str]:
+    if not _platform.startswith('openbsd'):
+        return None
+
+    which_netstat_result = subprocess.run(["which", "netstat"], capture_output=True)
+
+    if which_netstat_result.returncode == 0:
+        netstat = which_netstat_result.stdout.decode("UTF-8").strip()
+    else:
+        netstat = None
+
+    return netstat
+
+
 def gateways(old_api: bool = False) -> GatewaysTable:
     """
     Get the routing table indexed by interface type
@@ -217,6 +231,7 @@ def gateways(old_api: bool = False) -> GatewaysTable:
     """
 
     ip_tool_path = _ip_tool_path()
+    netstat_bsd_tool_path = _netstat_bsd_tool_path()
 
     if ip_tool_path:
         from .routes import routes_parse_ip_tool
@@ -228,6 +243,11 @@ def gateways(old_api: bool = False) -> GatewaysTable:
 
         logging.debug("Using route file")
         return routes_parse_file(_NIX_ROUTE_FILE.read_text(), old_api=old_api)
+    elif netstat_bsd_tool_path:
+        from .routes import routes_parse_netstat_tool
+
+        logging.debug("Using netstat tool")
+        return routes_parse_netstat_tool(netstat_bsd_tool_path, old_api=old_api)
     else:
         raise NotImplementedError("No implementation for `gateways()` yet")
 

--- a/python/netifaces/routes.py
+++ b/python/netifaces/routes.py
@@ -56,6 +56,43 @@ def routes_parse_ip_tool(ip_tool_path: str, old_api: bool = False) -> GatewaysTa
     return dict(table)
 
 
+def routes_parse_netstat_tool(netstat_tool_path: str, old_api: bool = False) -> GatewaysTable:
+    ipv4_query = subprocess.run([netstat_tool_path, "-r", "-n", "-f", "inet"], capture_output=True)
+    ipv6_query = subprocess.run([netstat_tool_path, "-r", "-n", "-f" ,"inet6"], capture_output=True)
+
+    if ipv4_query.returncode != 0 or ipv6_query.returncode != 0:
+        raise RuntimeError("Cannot use the netstat tool; although it is present on the system")
+
+    ipv4_lines = ipv4_query.stdout.decode("UTF-8").splitlines()
+    ipv6_lines = ipv6_query.stdout.decode("UTF-8").splitlines()
+
+    table: GatewaysTable = defaultdict(lambda *_: [])
+
+    for if_type, lines in [
+        (InterfaceType.AF_INET, ipv4_lines),
+        (InterfaceType.AF_INET6, ipv6_lines),
+    ]:
+        # Don't parse headers for routing tables
+        for line in lines[4:]:
+            cols = line.split()
+
+            default = cols[0] == "default"
+
+            # Check RTF_GATEWAY in flags for gateway
+            flags = cols[2]
+            if 'G' not in flags:
+                continue
+
+            gateway_ip = cols[1]
+            iface = cols[7]
+
+            table[if_type.value if old_api else if_type].append(
+                (gateway_ip, iface, True) if default else (gateway_ip, iface)
+            )
+
+    return dict(table)
+
+
 def routes_parse_file(content: str, old_api: bool = False) -> GatewaysTable:
     lined = content.splitlines()
 


### PR DESCRIPTION
On OpenBSD, parse output from `netstat -nr -f inet|inet6` to get gateways.

- `python/netifaces/__init__.py`: check if netstat tool is available (only true for OpenBSD) and use it to get gateways.
- `python/netifaces/routes.py`: add function `routes_parse_netstat_tool` to parse `netstat -nr` outputs.

---

**Tests OK** on OpenBSD:
```sh
$ netstat -nr -f inet
Routing tables

Internet:
Destination        Gateway            Flags   Refs      Use   Mtu  Prio Iface
default            10.0.2.2           UGS        5     2745     -     8 vio0 
224/4              127.0.0.1          URS        0        0 32768     8 lo0  
10.0.2/24          10.0.2.15          UCn        2        0     -     4 vio0 
10.0.2.2           52:55:0a:00:02:02  UHLch      3      303     -     3 vio0 
10.0.2.3           52:55:0a:00:02:03  UHLc       0       74     -     3 vio0 
10.0.2.15          52:54:00:12:34:56  UHLl       1      312     -     1 vio0 
10.0.2.255         10.0.2.15          UHb        0        0     -     1 vio0 
127/8              127.0.0.1          UGRS       0        0 32768     8 lo0  
127.0.0.1          127.0.0.1          UHhl       1      144 32768     1 lo0

$  python3
Python 3.12.10 (main, Apr 24 2025, 16:28:05) [Clang 16.0.6 ] on openbsd7
Type "help", "copyright", "credits" or "license" for more information.
>>> import netifaces
>>> netifaces.gateways()[netifaces.AF_INET]      
[('10.0.2.2', 'vio0', True), ('127.0.0.1', 'lo0')]
>>> netifaces.default_gateway()
{<InterfaceType.AF_INET: 2>: ('10.0.2.2', 'vio0')}
```